### PR TITLE
fix(lint): Fix matchers after the new analysis options made it to main

### DIFF
--- a/packages/test_track_test_support/test/helpers/matchers.dart
+++ b/packages/test_track_test_support/test/helpers/matchers.dart
@@ -17,7 +17,7 @@ class _OnlyContains<T> extends Matcher {
 
   @override
   Description describeMismatch(
-    item,
+    dynamic item,
     Description mismatchDescription,
     Map matchState,
     bool verbose,
@@ -40,7 +40,7 @@ class _OnlyContains<T> extends Matcher {
   }
 
   @override
-  bool matches(item, Map matchState) {
+  bool matches(dynamic item, Map matchState) {
     if (item is List<T>) {
       final items = [...item];
       if (items.length != _expected.length) {


### PR DESCRIPTION
The changes made in https://github.com/Betterment/test_track_dart_client/pull/6/files#diff-052069f98b8eed9d522e0701373983056bfbdc7ab6e98f99f6ca750a3257dce3R3-R7 forced an error in the custom matcher, fixing here.

/domain @samandmoore 
/no-platform