### PR TITLE
chore(ci): Set a default working dir on jobs during validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   validate_test_track:
-    name: Validate test_track
     uses: ./.github/workflows/validate.yml
     with:
       package-name: test_track
@@ -16,7 +15,6 @@ jobs:
       min-pana-score: 90
 
   validate_test_track_test_support:
-    name: Validate test_track_test_support
     uses: ./.github/workflows/validate.yml
     with:
       package-name: test_track_test_support
@@ -24,7 +22,6 @@ jobs:
       min-pana-score: 100
 
   validate_overall_test_coverage:
-    name: Validate Test Coverage
     runs-on: ubuntu-latest
     needs: [validate_test_track, validate_test_track_test_support]
     steps:


### PR DESCRIPTION
Sets a default `working-directory` for the `build` and `pana` jobs within the `validate` workflow so we don't need to declare it over and over

This PR is stacked on top of https://github.com/Betterment/test_track_dart_client/pull/11 which should merge first.

/domain @samandmoore @CelticMajora 
/no-platform