### PR TITLE
chore(ci): Set default working dir per job in validation workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,16 @@ jobs:
   validate_test_track:
     uses: ./.github/workflows/validate.yml
     with:
-      dir: packages/test_track
+      package-name: test_track
       code-gen: true
-      min-code-coverage: 89
+      min-code-coverage: 90
       min-pana-score: 90
 
   validate_test_track_test_support:
     uses: ./.github/workflows/validate.yml
     with:
-      dir: packages/test_track_test_support
+      package-name: test_track_test_support
       code-gen: false
-      min-code-coverage: 21
+      min-code-coverage: 90
       min-pana-score: 100
+

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,6 +9,9 @@ on:
       code-gen:
         required: true
         type: boolean
+      min-code-coverage:
+        required: true
+        type: number
       min-pana-score:
         required: true
         type: number
@@ -44,6 +47,15 @@ jobs:
 
       - name: Run tests and generate coverage report
         run: ../../tool/generate_code_coverage.sh
+
+      - name: Report code coverage
+        uses: zgosalvez/github-actions-report-lcov@v1.4.0
+        with:
+          coverage-files: packages/${{ inputs.package-name }}/coverage/lcov.info
+          minimum-coverage: ${{ inputs.min-code-coverage }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-name: code-coverage-report
+          working-directory: packages/${{ inputs.package-name }}
 
       - name: Archive code coverage results
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Sets `working-dir` at the job level so we don't need to repeat that on each step of each job 🎉 

/domain @samandmoore @CelticMajora 
/no-platform