### PR TITLE
chore: Resolve pana static analysis issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       package-name: test_track
       code-gen: true
       min-code-coverage: 90
-      min-pana-score: 90
+      min-pana-score: 110
 
   validate_test_track_test_support:
     uses: ./.github/workflows/validate.yml
@@ -21,5 +21,5 @@ jobs:
       package-name: test_track_test_support
       code-gen: false
       min-code-coverage: 90
-      min-pana-score: 100
+      min-pana-score: 110
 

--- a/packages/test_track/build.yaml
+++ b/packages/test_track/build.yaml
@@ -1,6 +1,10 @@
 targets:
   $default:
     builders:
+      source_gen|combining_builder:
+        options:
+          ignore_for_file:
+          - non_constant_identifier_names
       json_serializable:
         options:
           # Options configure how source code is generated for every

--- a/packages/test_track/lib/src/models/app_version_build.g.dart
+++ b/packages/test_track/lib/src/models/app_version_build.g.dart
@@ -1,5 +1,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
+// ignore_for_file: non_constant_identifier_names
+
 part of 'app_version_build.dart';
 
 // **************************************************************************

--- a/packages/test_track/lib/src/models/app_visitor_config.g.dart
+++ b/packages/test_track/lib/src/models/app_visitor_config.g.dart
@@ -1,5 +1,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
+// ignore_for_file: non_constant_identifier_names
+
 part of 'app_visitor_config.dart';
 
 // **************************************************************************

--- a/packages/test_track/lib/src/models/assignment.g.dart
+++ b/packages/test_track/lib/src/models/assignment.g.dart
@@ -1,5 +1,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
+// ignore_for_file: non_constant_identifier_names
+
 part of 'assignment.dart';
 
 // **************************************************************************

--- a/packages/test_track/lib/src/models/assignment_event.g.dart
+++ b/packages/test_track/lib/src/models/assignment_event.g.dart
@@ -1,5 +1,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
+// ignore_for_file: non_constant_identifier_names
+
 part of 'assignment_event.dart';
 
 // **************************************************************************

--- a/packages/test_track/lib/src/models/identifier.g.dart
+++ b/packages/test_track/lib/src/models/identifier.g.dart
@@ -1,5 +1,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
+// ignore_for_file: non_constant_identifier_names
+
 part of 'identifier.dart';
 
 // **************************************************************************

--- a/packages/test_track/lib/src/models/split.dart
+++ b/packages/test_track/lib/src/models/split.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: invalid_annotation_target
+
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:test_track/src/models/variant.dart';
 
@@ -16,7 +18,6 @@ class Split with _$Split {
   const factory Split({
     required String name,
     required List<Variant> variants,
-    // ignore: invalid_annotation_target
     @JsonKey(name: 'feature_gate') required bool isFeatureGate,
   }) = _Split;
 

--- a/packages/test_track/lib/src/models/split.freezed.dart
+++ b/packages/test_track/lib/src/models/split.freezed.dart
@@ -44,8 +44,7 @@ const $Split = _$SplitTearOff();
 /// @nodoc
 mixin _$Split {
   String get name => throw _privateConstructorUsedError;
-  List<Variant> get variants =>
-      throw _privateConstructorUsedError; // ignore: invalid_annotation_target
+  List<Variant> get variants => throw _privateConstructorUsedError;
   @JsonKey(name: 'feature_gate')
   bool get isFeatureGate => throw _privateConstructorUsedError;
 
@@ -153,7 +152,7 @@ class _$_Split implements _Split {
   final String name;
   @override
   final List<Variant> variants;
-  @override // ignore: invalid_annotation_target
+  @override
   @JsonKey(name: 'feature_gate')
   final bool isFeatureGate;
 
@@ -203,7 +202,7 @@ abstract class _Split implements Split {
   String get name;
   @override
   List<Variant> get variants;
-  @override // ignore: invalid_annotation_target
+  @override
   @JsonKey(name: 'feature_gate')
   bool get isFeatureGate;
   @override

--- a/packages/test_track/lib/src/models/split.g.dart
+++ b/packages/test_track/lib/src/models/split.g.dart
@@ -1,5 +1,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
+// ignore_for_file: non_constant_identifier_names
+
 part of 'split.dart';
 
 // **************************************************************************

--- a/packages/test_track/lib/src/models/split_registry.g.dart
+++ b/packages/test_track/lib/src/models/split_registry.g.dart
@@ -1,5 +1,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
+// ignore_for_file: non_constant_identifier_names
+
 part of 'split_registry.dart';
 
 // **************************************************************************

--- a/packages/test_track/lib/src/models/variant.g.dart
+++ b/packages/test_track/lib/src/models/variant.g.dart
@@ -1,5 +1,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
+// ignore_for_file: non_constant_identifier_names
+
 part of 'variant.dart';
 
 // **************************************************************************

--- a/packages/test_track/lib/src/models/visitor.g.dart
+++ b/packages/test_track/lib/src/models/visitor.g.dart
@@ -1,5 +1,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
+// ignore_for_file: non_constant_identifier_names
+
 part of 'visitor.dart';
 
 // **************************************************************************


### PR DESCRIPTION
### 📰 Summary of changes
<!-- Feel free to delete this section if it doesn't apply -->
> What is the new functionality added in this PR?

Pana was complaining about static analysis issues we were _not_ seeing using `dart analyze` locally:

![Screen Shot 2022-02-23 at 16 55 59](https://user-images.githubusercontent.com/8343465/155415394-5ffae4b7-b5d4-4c5a-b669-0ee9a714ca35.png)

Did some sleuthing and came across [this ticket](https://github.com/dart-lang/pana/issues/1013) where I found out that this behavior is intentional -- pana will scan files, even those you exclude, so that all packages can be held to the same standard, but the ironic part is that the expectation is you add `ignore` statements to get around these issues 🙃 

Either way, we resolve that here by adding to our `build.yaml` so all generated files will ignore the `non_constant_identifier_names` lint rule. We also move from a line `ignore` to a `file` ignore for `invalid_annotation_target` in `split.dart` because I believe `freezed` is adding that to files itself, and since it was being added to the file _and_ the line, `pana` complained. By adding it as a file `ignore` it gets de-duped and `pana` is satisfied.

### 🧪 Testing done
<!-- Feel free to delete this section if it doesn't apply -->
> What testing was added to cover the functionality added in this PR

Locally via `pana`

### Reviewers
<!-- This is used by us to signal to the correct people that your PR needs review -->
/domain @samandmoore 
/no-platform
