### PR TITLE
ci: Use codecov instead of the lcov reporter

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -47,21 +47,11 @@ jobs:
 
       - name: Run tests and generate coverage report
         run: ../../tool/generate_code_coverage.sh
-
-      - name: Report code coverage
-        uses: zgosalvez/github-actions-report-lcov@v1.4.0
+        
+      - uses: codecov/codecov-action@v2
         with:
-          coverage-files: packages/${{ inputs.package-name }}/coverage/lcov.info
-          minimum-coverage: ${{ inputs.min-code-coverage }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-name: code-coverage-report
+          files: packages/${{ inputs.package-name }}/coverage/lcov.info
           working-directory: packages/${{ inputs.package-name }}
-
-      - name: Archive code coverage results
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ inputs.package-name }}-code-coverage
-          path: packages/${{ inputs.package-name }}/coverage/lcov.info
 
   pana:
       runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This is the testing support package intended to facilitate easy integration test
 [build_status_badge]: https://github.com/Betterment/test_track_dart_client/actions/workflows/ci.yml/badge.svg?branch=main
 [build_status_link]: https://github.com/Betterment/test_track_dart_client/actions/workflows/ci.yml?query=branch%3Amain
 [code_coverage_badge]: https://codecov.io/gh/Betterment/test_track_dart_client/branch/main/graph/badge.svg?token=T1EJRQVZFH
-[code_coverage_badge_link]: https://codecov.io/gh/Betterment/test_track_dart_client/branch/main/graph/badge.svg?token=T1EJRQVZFH)](https://codecov.io/gh/Betterment/test_track_dart_client
+[code_coverage_badge_link]:https://codecov.io/gh/Betterment/test_track_dart_client
 [license_badge]: https://img.shields.io/badge/License-MIT-yellow.svg
 [license_link]: https://opensource.org/licenses/MIT
 [maintenance_badge]: https://img.shields.io/badge/Maintained%3F-yes-green.svg

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build status][build_status_badge]][build_status_link]
 [![Maintenance][maintenance_badge]][maintenance_link]
 [![License: MIT][license_badge]][license_link]
+[![codecov][code_coverage_badge]][code_coverage_badge_link]
 
 This repository hosts the [TestTrack dart client][test-track-dart-client] as well as its [testing support package][test-track-test-support].
 
@@ -23,6 +24,8 @@ This is the testing support package intended to facilitate easy integration test
 
 [build_status_badge]: https://github.com/Betterment/test_track_dart_client/actions/workflows/ci.yml/badge.svg?branch=main
 [build_status_link]: https://github.com/Betterment/test_track_dart_client/actions/workflows/ci.yml?query=branch%3Amain
+[code_coverage_badge]: https://codecov.io/gh/Betterment/test_track_dart_client/branch/main/graph/badge.svg?token=T1EJRQVZFH
+[code_coverage_badge_link]: https://codecov.io/gh/Betterment/test_track_dart_client/branch/main/graph/badge.svg?token=T1EJRQVZFH)](https://codecov.io/gh/Betterment/test_track_dart_client
 [license_badge]: https://img.shields.io/badge/License-MIT-yellow.svg
 [license_link]: https://opensource.org/licenses/MIT
 [maintenance_badge]: https://img.shields.io/badge/Maintained%3F-yes-green.svg

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  range: "90...100"
+  status:
+    project:
+      target: 92
+      test_track_dart_client:
+        paths:
+          - packages/test_track_dart_client/*
+      test_track_test_support:
+        target: 100
+        paths:
+          - packages/test_track_test_support/*


### PR DESCRIPTION
### 📰 Summary of changes
<!-- Feel free to delete this section if it doesn't apply -->
> What is the new functionality added in this PR?

- Switching CI up to use `codecov` instead of `zgosalvez/github-actions-report-lcov@v1.4.0`. `codecov` will upload the `lcov` info for nice graph viewing and viewing coverage across commits
- Because of this, we no longer need to store the artifact either, we can just view codecov
- Codecov is free for open-source projects

### 🧪 Testing done
<!-- Feel free to delete this section if it doesn't apply -->
> What testing was added to cover the functionality added in this PR

I explored this with my own repo [here](https://github.com/btrautmann/hydrawise-companion/pull/50), and it was super easy to integrate.

### Reviewers
<!-- This is used by us to signal to the correct people that your PR needs review -->
/domain @samandmoore @CelticMajora 
/no-platform
