### PR TITLE
fix: add required headers to all requests via Interceptor

### DIFF
--- a/packages/test_track/lib/src/networking/http_client.dart
+++ b/packages/test_track/lib/src/networking/http_client.dart
@@ -2,6 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:test_track/src/helpers/extensions.dart';
 import 'package:test_track/src/logging/logging.dart';
 import 'package:test_track/src/networking/interceptors/logging_interceptor.dart';
+import 'package:test_track/src/networking/interceptors/required_headers_interceptor.dart';
 import 'package:test_track/src/networking/interceptors/retry_interceptor.dart';
 
 /// {@template http_client}
@@ -27,6 +28,7 @@ class HttpClient {
             ..options.receiveTimeout = const Duration(seconds: 20)
             ..map((dio) {
               final interceptors = [
+                RequiredHeadersInterceptor(),
                 LoggingInterceptor(logger: logger),
                 RetryInterceptor(dio: dio),
               ];

--- a/packages/test_track/lib/src/networking/interceptors/logging_interceptor.dart
+++ b/packages/test_track/lib/src/networking/interceptors/logging_interceptor.dart
@@ -14,13 +14,15 @@ class LoggingInterceptor extends Interceptor {
   }) : _logger = logger;
 
   @override
-  Future onRequest(RequestOptions options, RequestInterceptorHandler handler) async {
+  Future onRequest(
+      RequestOptions options, RequestInterceptorHandler handler) async {
     if (!_logger.shouldEnableNetworkLogging) {
       super.onRequest(options, handler);
       return;
     }
 
-    _logger.debug('TestTrack HttpClient - ⬆️ [${options.method}] ${options.uri}');
+    _logger
+        .debug('TestTrack HttpClient - ⬆️ [${options.method}] ${options.uri}');
     _logger.debug('headers: ${options.headers}');
     if (options.data != null) {
       _logger.debug('\t data: ${options.data}');
@@ -35,7 +37,9 @@ class LoggingInterceptor extends Interceptor {
       return;
     }
 
-    final statusCode = err.response?.statusCode != null ? ' [${err.response?.statusCode}]' : '';
+    final statusCode = err.response?.statusCode != null
+        ? ' [${err.response?.statusCode}]'
+        : '';
     final requestUri = ' ${err.requestOptions.uri}';
 
     _logger.debug('TestTrack HttpClient - 🛑 ERROR$statusCode$requestUri');
@@ -49,13 +53,15 @@ class LoggingInterceptor extends Interceptor {
   }
 
   @override
-  Future onResponse(Response response, ResponseInterceptorHandler handler) async {
+  Future onResponse(
+      Response response, ResponseInterceptorHandler handler) async {
     if (!_logger.shouldEnableNetworkLogging) {
       super.onResponse(response, handler);
       return;
     }
 
-    _logger.debug('TestTrack HttpClient - ⬇️ [${response.statusCode}] ${response.requestOptions.uri}');
+    _logger.debug(
+        'TestTrack HttpClient - ⬇️ [${response.statusCode}] ${response.requestOptions.uri}');
     if (response.data != null) {
       _logger.debug('\t data: ${response.data}');
     }

--- a/packages/test_track/lib/src/networking/interceptors/logging_interceptor.dart
+++ b/packages/test_track/lib/src/networking/interceptors/logging_interceptor.dart
@@ -14,15 +14,14 @@ class LoggingInterceptor extends Interceptor {
   }) : _logger = logger;
 
   @override
-  Future onRequest(
-      RequestOptions options, RequestInterceptorHandler handler) async {
+  Future onRequest(RequestOptions options, RequestInterceptorHandler handler) async {
     if (!_logger.shouldEnableNetworkLogging) {
       super.onRequest(options, handler);
       return;
     }
 
-    _logger
-        .debug('TestTrack HttpClient - ⬆️ [${options.method}] ${options.uri}');
+    _logger.debug('TestTrack HttpClient - ⬆️ [${options.method}] ${options.uri}');
+    _logger.debug('headers: ${options.headers}');
     if (options.data != null) {
       _logger.debug('\t data: ${options.data}');
     }
@@ -36,9 +35,7 @@ class LoggingInterceptor extends Interceptor {
       return;
     }
 
-    final statusCode = err.response?.statusCode != null
-        ? ' [${err.response?.statusCode}]'
-        : '';
+    final statusCode = err.response?.statusCode != null ? ' [${err.response?.statusCode}]' : '';
     final requestUri = ' ${err.requestOptions.uri}';
 
     _logger.debug('TestTrack HttpClient - 🛑 ERROR$statusCode$requestUri');
@@ -52,15 +49,13 @@ class LoggingInterceptor extends Interceptor {
   }
 
   @override
-  Future onResponse(
-      Response response, ResponseInterceptorHandler handler) async {
+  Future onResponse(Response response, ResponseInterceptorHandler handler) async {
     if (!_logger.shouldEnableNetworkLogging) {
       super.onResponse(response, handler);
       return;
     }
 
-    _logger.debug(
-        'TestTrack HttpClient - ⬇️ [${response.statusCode}] ${response.requestOptions.uri}');
+    _logger.debug('TestTrack HttpClient - ⬇️ [${response.statusCode}] ${response.requestOptions.uri}');
     if (response.data != null) {
       _logger.debug('\t data: ${response.data}');
     }

--- a/packages/test_track/lib/src/networking/interceptors/required_headers_interceptor.dart
+++ b/packages/test_track/lib/src/networking/interceptors/required_headers_interceptor.dart
@@ -3,16 +3,16 @@ import 'package:dio/dio.dart';
 /// An [Interceptor] that adds headers required to communicate with TestTrack to each
 /// request.
 class RequiredHeadersInterceptor extends Interceptor {
+  static const _requiredHeaders = <String, String>{
+    Headers.acceptHeader: 'application/json; charset=utf-8',
+    Headers.contentTypeHeader: 'application/json; charset=utf-8',
+  };
   @override
   Future onRequest(
       RequestOptions options, RequestInterceptorHandler handler) async {
-    const requiredHeaders = <String, String>{
-      Headers.acceptHeader: 'application/json; charset=utf-8',
-      Headers.contentTypeHeader: 'application/json; charset=utf-8',
-    };
     return super.onRequest(
       options.copyWith(
-        headers: options.headers..addAll(requiredHeaders),
+        headers: options.headers..addAll(_requiredHeaders),
       ),
       handler,
     );

--- a/packages/test_track/lib/src/networking/interceptors/required_headers_interceptor.dart
+++ b/packages/test_track/lib/src/networking/interceptors/required_headers_interceptor.dart
@@ -4,7 +4,8 @@ import 'package:dio/dio.dart';
 /// request.
 class RequiredHeadersInterceptor extends Interceptor {
   @override
-  Future onRequest(RequestOptions options, RequestInterceptorHandler handler) async {
+  Future onRequest(
+      RequestOptions options, RequestInterceptorHandler handler) async {
     final requiredHeaders = <String, String>{
       Headers.acceptHeader: 'application/json; charset=utf-8',
       Headers.contentTypeHeader: 'application/json; charset=utf-8',

--- a/packages/test_track/lib/src/networking/interceptors/required_headers_interceptor.dart
+++ b/packages/test_track/lib/src/networking/interceptors/required_headers_interceptor.dart
@@ -1,0 +1,19 @@
+import 'package:dio/dio.dart';
+
+/// An [Interceptor] that adds headers required to communicate with TestTrack to each
+/// request.
+class RequiredHeadersInterceptor extends Interceptor {
+  @override
+  Future onRequest(RequestOptions options, RequestInterceptorHandler handler) async {
+    final requiredHeaders = <String, String>{
+      Headers.acceptHeader: 'application/json; charset=utf-8',
+      Headers.contentTypeHeader: 'application/json; charset=utf-8',
+    };
+    return super.onRequest(
+      options.copyWith(
+        headers: options.headers..addAll(requiredHeaders),
+      ),
+      handler,
+    );
+  }
+}

--- a/packages/test_track/lib/src/networking/interceptors/required_headers_interceptor.dart
+++ b/packages/test_track/lib/src/networking/interceptors/required_headers_interceptor.dart
@@ -6,7 +6,7 @@ class RequiredHeadersInterceptor extends Interceptor {
   @override
   Future onRequest(
       RequestOptions options, RequestInterceptorHandler handler) async {
-    final requiredHeaders = <String, String>{
+    const requiredHeaders = <String, String>{
       Headers.acceptHeader: 'application/json; charset=utf-8',
       Headers.contentTypeHeader: 'application/json; charset=utf-8',
     };

--- a/packages/test_track/pubspec.yaml
+++ b/packages/test_track/pubspec.yaml
@@ -1,6 +1,6 @@
 name: test_track
 description: The dart client for the TestTrack system. It provides client-side split-testing and feature-toggling through a simple API.
-version: 0.0.4
+version: 0.0.5
 homepage: https://github.com/Betterment/test_track_dart_client
 repository: https://github.com/Betterment/test_track_dart_client
 

--- a/packages/test_track/test/networking/fakes/fake_request_interceptor_handler.dart
+++ b/packages/test_track/test/networking/fakes/fake_request_interceptor_handler.dart
@@ -1,0 +1,12 @@
+import 'package:dio/dio.dart';
+
+class FakeRequestInterceptorHandler extends RequestInterceptorHandler {
+  final void Function(RequestOptions options) onNext;
+
+  FakeRequestInterceptorHandler({required this.onNext});
+
+  @override
+  void next(RequestOptions requestOptions) {
+    return onNext(requestOptions);
+  }
+}

--- a/packages/test_track/test/networking/interceptors/logging_interceptor_test.dart
+++ b/packages/test_track/test/networking/interceptors/logging_interceptor_test.dart
@@ -26,12 +26,16 @@ void main() {
         final subject = buildSubject(logger: logger);
         final requestOptions = MockRequestOptions();
         when(() => requestOptions.method).thenReturn('');
+        when(() => requestOptions.headers)
+            .thenReturn(<String, String>{'beep': 'bop'});
         when(() => requestOptions.uri).thenReturn(Uri.base);
 
         await subject.onRequest(requestOptions, RequestInterceptorHandler());
 
-        final logEvent = logger.debugLogs.single;
-        expect(logEvent.message, contains('TestTrack HttpClient - ⬆️'));
+        final mainLogEvent = logger.debugLogs.first;
+        final headersLogEvent = logger.debugLogs.last;
+        expect(mainLogEvent.message, contains('TestTrack HttpClient - ⬆️'));
+        expect(headersLogEvent.message, 'headers: {beep: bop}');
       });
 
       test(

--- a/packages/test_track/test/networking/interceptors/required_headers_interceptor_test.dart
+++ b/packages/test_track/test/networking/interceptors/required_headers_interceptor_test.dart
@@ -1,0 +1,22 @@
+import 'package:charlatan/charlatan.dart';
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+import 'package:test_track/src/networking/interceptors/required_headers_interceptor.dart';
+
+import '../fakes/fake_request_interceptor_handler.dart';
+
+void main() {
+  group('RequiredHeadersInterceptor', () {
+    test('it adds expected headers', () {
+      late final Map<String, dynamic>? headers;
+      final subject = RequiredHeadersInterceptor();
+      subject.onRequest(
+        RequestOptions(path: '/foo', headers: <String, String>{}),
+        FakeRequestInterceptorHandler(onNext: (options) => headers = options.headers),
+      );
+
+      expect(headers![Headers.acceptHeader], 'application/json; charset=utf-8');
+      expect(headers![Headers.contentTypeHeader], 'application/json; charset=utf-8');
+    });
+  });
+}

--- a/packages/test_track/test/networking/interceptors/required_headers_interceptor_test.dart
+++ b/packages/test_track/test/networking/interceptors/required_headers_interceptor_test.dart
@@ -12,11 +12,13 @@ void main() {
       final subject = RequiredHeadersInterceptor();
       subject.onRequest(
         RequestOptions(path: '/foo', headers: <String, String>{}),
-        FakeRequestInterceptorHandler(onNext: (options) => headers = options.headers),
+        FakeRequestInterceptorHandler(
+            onNext: (options) => headers = options.headers),
       );
 
       expect(headers![Headers.acceptHeader], 'application/json; charset=utf-8');
-      expect(headers![Headers.contentTypeHeader], 'application/json; charset=utf-8');
+      expect(headers![Headers.contentTypeHeader],
+          'application/json; charset=utf-8');
     });
   });
 }


### PR DESCRIPTION
### 📰 Summary of changes
<!-- Feel free to delete this section if it doesn't apply -->
> What is the new functionality added in this PR?

In [this PR](https://github.com/Betterment/test_track_dart_client/pull/32) we upgraded to Dio `5.0.0` which removed the automatic setting of content type and accept headers. This actually breaks communication with `TestTrack`. This PR adds these headers back.

### 🧪 Testing done
<!-- Feel free to delete this section if it doesn't apply -->
> What testing was added to cover the functionality added in this PR

- Manual testing using host application
- Added unit test to ensure correct headers are added to each request