### PR TITLE
feat: add systomProxyGetter parameter to allow for proxying requests

### DIFF
--- a/packages/test_track/lib/src/helpers/utils.dart
+++ b/packages/test_track/lib/src/helpers/utils.dart
@@ -1,0 +1,6 @@
+/// Returns true if the current build is a debug build.
+bool isDebug() {
+  var isDebug = false;
+  assert(isDebug = true, "Assertions only run in debug mode.");
+  return isDebug;
+}

--- a/packages/test_track/lib/src/networking/interceptors/system_proxy_interceptor.dart
+++ b/packages/test_track/lib/src/networking/interceptors/system_proxy_interceptor.dart
@@ -1,0 +1,56 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:test_track/src/helpers/utils.dart';
+
+/// A function that returns a map of proxy settings.
+typedef SystemProxyGetter = Future<Map<String, String>?> Function();
+
+/// {@template system_proxy_interceptor}
+/// An interceptor that sets the system proxy. If the [SystemProxyGetter] returns
+/// null, the request handled by [onRequest] will not be impacted.
+///
+/// This allows us to set the system proxy uniquely for each request which means
+/// the correct proxy will be used if it changes at runtime.
+/// {@endtemplate}
+class SystemProxyInterceptor extends Interceptor {
+  /// {@macro system_proxy_interceptor}
+  SystemProxyInterceptor({
+    required SystemProxyGetter systemProxyGetter,
+  }) : _systemProxyGetter = systemProxyGetter;
+
+  final SystemProxyGetter _systemProxyGetter;
+
+  @override
+  Future<void> onRequest(
+      RequestOptions options, RequestInterceptorHandler handler) async {
+    final proxy = await _systemProxyGetter();
+
+    if (proxy != null) {
+      final host = proxy['host'];
+      final port = proxy['port'];
+      final proxyString = '$host:$port';
+
+      HttpOverrides.global = _HttpOverrides(
+        clientBuilder: (client) => client
+          ..badCertificateCallback = (cert, host, port) {
+            return Platform.isAndroid && isDebug();
+          }
+          ..findProxy = (_) => 'PROXY $proxyString',
+      );
+    }
+
+    return super.onRequest(options, handler);
+  }
+}
+
+class _HttpOverrides extends HttpOverrides {
+  _HttpOverrides({required this.clientBuilder});
+
+  final HttpClient Function(HttpClient) clientBuilder;
+
+  @override
+  HttpClient createHttpClient(SecurityContext? context) {
+    return clientBuilder(super.createHttpClient(context));
+  }
+}

--- a/packages/test_track/lib/src/test_track.dart
+++ b/packages/test_track/lib/src/test_track.dart
@@ -6,6 +6,7 @@ import 'package:test_track/src/domain/domain.dart';
 import 'package:test_track/src/logging/default_test_track_logger.dart';
 import 'package:test_track/src/networking/interceptors/logging_interceptor.dart';
 import 'package:test_track/src/networking/interceptors/retry_interceptor.dart';
+import 'package:test_track/src/networking/interceptors/system_proxy_interceptor.dart';
 import 'package:test_track/test_track.dart';
 
 /// The instance with which to interact to perform
@@ -31,6 +32,7 @@ class TestTrack {
     required AnalyticsProvider analyticsProvider,
     HttpClientAdapter? customHttpAdapter,
     TestTrackLogger? logger,
+    Future<Map<String, String>?> Function()? systemProxyGetter,
   }) async {
     logger ??= const SilentTestTrackLogger();
 
@@ -39,6 +41,8 @@ class TestTrack {
       baseUrl: baseUrl,
       interceptors: [
         LoggingInterceptor(logger: logger),
+        if (systemProxyGetter != null)
+          SystemProxyInterceptor(systemProxyGetter: systemProxyGetter),
         RetryInterceptor(clientGetter: () => client),
       ],
       customAdapter: customHttpAdapter,

--- a/packages/test_track/test/networking/interceptors/system_proxy_interceptor_test.dart
+++ b/packages/test_track/test/networking/interceptors/system_proxy_interceptor_test.dart
@@ -9,8 +9,11 @@ import '../fakes/fake_request_interceptor_handler.dart';
 void main() {
   group('SystemProxyInterceptor', () {
     group('when proxy getter returns null', () {
-      final subject =
-          SystemProxyInterceptor(systemProxyGetter: () async => null);
+      final subject = SystemProxyInterceptor(
+        systemProxyGetter: () async => null,
+      );
+
+      setUp(() => HttpOverrides.global = null);
 
       test('it does not set HttpOverrides', () async {
         await subject.onRequest(

--- a/packages/test_track/test/networking/interceptors/system_proxy_interceptor_test.dart
+++ b/packages/test_track/test/networking/interceptors/system_proxy_interceptor_test.dart
@@ -1,0 +1,42 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+import 'package:test_track/src/networking/interceptors/system_proxy_interceptor.dart';
+
+import '../fakes/fake_request_interceptor_handler.dart';
+
+void main() {
+  group('SystemProxyInterceptor', () {
+    group('when proxy getter returns null', () {
+      final subject =
+          SystemProxyInterceptor(systemProxyGetter: () async => null);
+
+      test('it does not set HttpOverrides', () async {
+        await subject.onRequest(
+          RequestOptions(path: '/foo'),
+          FakeRequestInterceptorHandler(
+            onNext: (_) {},
+          ),
+        );
+        expect(HttpOverrides.current, isNull);
+      });
+    });
+
+    group('when proxy getter returns non-null', () {
+      final subject = SystemProxyInterceptor(
+        systemProxyGetter: () async => {'host': 'foo', 'port': 'bar'},
+      );
+
+      test('it sets HttpOverrides', () async {
+        await subject.onRequest(
+          RequestOptions(path: '/foo'),
+          FakeRequestInterceptorHandler(
+            onNext: (_) {},
+          ),
+        );
+        expect(HttpOverrides.current, isNotNull);
+      });
+    });
+  });
+}


### PR DESCRIPTION
### 📰 Summary of changes
<!-- Feel free to delete this section if it doesn't apply -->
> What is the new functionality added in this PR?

This PR adds a `systemProxyGetter` parameter to the `TestTrack` SDK instance to allow proxying requests. If `null` (the default) requests will not be impacted. If non-null, an `Interceptor` will be added to the `SturdyHttp` instance that checks for the existence of `host` and `port` in the returned `Map` and overrides the system `HttpClient` with one containing the desired proxy settings.

### 🧪 Testing done
<!-- Feel free to delete this section if it doesn't apply -->
> What testing was added to cover the functionality added in this PR

Added unit tests to verify `HttpClient` is being overridden. It's a bit tricky to test the actual data being overridden (because it involves interacting with the system `HttpClient`, but I did manually validate this.
