### PR TITLE
fix: avoid calling handler.next more than once in RetryInterceptor

### DIFF
--- a/packages/test_track/lib/src/networking/interceptors/retry_interceptor.dart
+++ b/packages/test_track/lib/src/networking/interceptors/retry_interceptor.dart
@@ -29,13 +29,16 @@ class RetryInterceptor extends Interceptor {
     DioException err,
     ErrorInterceptorHandler handler,
   ) async {
-    var extra = RetryOptions.fromRequestOptions(err.requestOptions) ?? _retryOptions;
-    final isIdempotent = err.requestOptions.extra[isIdempotentOptionsKey] as bool? ?? false;
+    var extra =
+        RetryOptions.fromRequestOptions(err.requestOptions) ?? _retryOptions;
+    final isIdempotent =
+        err.requestOptions.extra[isIdempotentOptionsKey] as bool? ?? false;
     final originalMethod = err.requestOptions.method;
     final capitalizedMethod = StringBuffer()
       ..write(originalMethod.substring(0, 1).toUpperCase())
       ..write(originalMethod.substring(1).toLowerCase());
-    final requestType = NetworkRequestType.values.byName(capitalizedMethod.toString());
+    final requestType =
+        NetworkRequestType.values.byName(capitalizedMethod.toString());
 
     if (extra.shouldRetry(err, isIdempotent: isIdempotent)) {
       if (extra.retryInterval.inMilliseconds > 0) {

--- a/packages/test_track/lib/src/networking/interceptors/retry_interceptor.dart
+++ b/packages/test_track/lib/src/networking/interceptors/retry_interceptor.dart
@@ -26,17 +26,16 @@ class RetryInterceptor extends Interceptor {
 
   @override
   Future<void> onError(
-      DioException err, ErrorInterceptorHandler handler) async {
-    var extra =
-        RetryOptions.fromRequestOptions(err.requestOptions) ?? _retryOptions;
-    final isIdempotent =
-        err.requestOptions.extra[isIdempotentOptionsKey] as bool? ?? false;
+    DioException err,
+    ErrorInterceptorHandler handler,
+  ) async {
+    var extra = RetryOptions.fromRequestOptions(err.requestOptions) ?? _retryOptions;
+    final isIdempotent = err.requestOptions.extra[isIdempotentOptionsKey] as bool? ?? false;
     final originalMethod = err.requestOptions.method;
     final capitalizedMethod = StringBuffer()
       ..write(originalMethod.substring(0, 1).toUpperCase())
       ..write(originalMethod.substring(1).toLowerCase());
-    final requestType =
-        NetworkRequestType.values.byName(capitalizedMethod.toString());
+    final requestType = NetworkRequestType.values.byName(capitalizedMethod.toString());
 
     if (extra.shouldRetry(err, isIdempotent: isIdempotent)) {
       if (extra.retryInterval.inMilliseconds > 0) {
@@ -98,8 +97,8 @@ class RetryInterceptor extends Interceptor {
       } on DioException catch (err) {
         return super.onError(err, handler);
       }
+    } else {
+      super.onError(err, handler);
     }
-
-    super.onError(err, handler);
   }
 }

--- a/packages/test_track/test/networking/fakes/fake_error_interceptor_handler.dart
+++ b/packages/test_track/test/networking/fakes/fake_error_interceptor_handler.dart
@@ -22,6 +22,5 @@ class FakeErrorInterceptorHandler extends ErrorInterceptorHandler {
   @override
   void resolve(Response<dynamic> response) {
     _onResolveInvoked?.call(response);
-    super.resolve(response);
   }
 }

--- a/packages/test_track/test/networking/fakes/fake_http_client.dart
+++ b/packages/test_track/test/networking/fakes/fake_http_client.dart
@@ -5,6 +5,8 @@ class FakeSturdyHttp extends SturdyHttp {
   FakeSturdyHttp(
     Charlatan charlatan,
   ) : super(
-            baseUrl: 'http://localhost',
-            customAdapter: charlatan.toFakeHttpClientAdapter());
+          baseUrl: 'http://localhost',
+          customAdapter: charlatan.toFakeHttpClientAdapter(),
+          inferContentType: false,
+        );
 }

--- a/packages/test_track/test/networking/interceptors/retry_interceptor_test.dart
+++ b/packages/test_track/test/networking/interceptors/retry_interceptor_test.dart
@@ -65,9 +65,7 @@ void main() {
         }
 
         group('and the retry request succeeds', () {
-          test(
-              'it retries the request with dio and returns the successful response',
-              () async {
+          test('it retries the request with dio and returns the successful response', () async {
             late final Response<dynamic> response;
             final handler = FakeErrorInterceptorHandler(
               onResolveInvoked: (res) => response = res,

--- a/packages/test_track/test/networking/interceptors/retry_interceptor_test.dart
+++ b/packages/test_track/test/networking/interceptors/retry_interceptor_test.dart
@@ -65,7 +65,9 @@ void main() {
         }
 
         group('and the retry request succeeds', () {
-          test('it retries the request with dio and returns the successful response', () async {
+          test(
+              'it retries the request with dio and returns the successful response',
+              () async {
             late final Response<dynamic> response;
             final handler = FakeErrorInterceptorHandler(
               onResolveInvoked: (res) => response = res,


### PR DESCRIPTION
### 📰 Summary of changes
<!-- Feel free to delete this section if it doesn't apply -->
> What is the new functionality added in this PR?

This PR fixes an issue where the `RetryInterceptor` would call `super.onError` twice while processing a request which is not allowed (because under the hood, this calls `handler.next` which invokes a `Completer`s completion logic and this can only be done once).
