### PR TITLE
chore: Prep 0.1.5 release

### DIFF
--- a/packages/test_track/CHANGELOG.md
+++ b/packages/test_track/CHANGELOG.md
@@ -1,7 +1,16 @@
+## 0.1.5
+
+## What's Changed
+* chore: Upgrade `dio`, `sturdy_http` by @willlockwood in https://github.com/Betterment/test_track_dart_client/pull/50
+
+## New Contributors
+* @willlockwood made their first contribution in https://github.com/Betterment/test_track_dart_client/pull/50
+
+**Full Changelog**: https://github.com/Betterment/test_track_dart_client/compare/v0.1.4...v.0.1.5
+
 ## 0.1.4
 
 * chore: update dependencies and dart by @ClaireDavis in https://github.com/Betterment/test_track_dart_client/pull/47
-
 
 **Full Changelog**: https://github.com/Betterment/test_track_dart_client/compare/v0.1.3...v0.1.4
 

--- a/packages/test_track/pubspec.yaml
+++ b/packages/test_track/pubspec.yaml
@@ -1,6 +1,6 @@
 name: test_track
 description: The dart client for the TestTrack system. It provides client-side split-testing and feature-toggling through a simple API.
-version: 0.1.4
+version: 0.1.5
 homepage: https://github.com/Betterment/test_track_dart_client
 repository: https://github.com/Betterment/test_track_dart_client
 


### PR DESCRIPTION
### 📰 Summary of changes

Prepping `test_track` v.0.1.5 release.
