### PR TITLE
feat: allow basic auth to be provided to assign overrides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,4 +68,4 @@ jobs:
           dart pub global activate melos 2.3.1 && melos bs
           dart pub global activate pana
       - name: Verify pub score
-        run: melos exec -- "../../tool/verify_pub_score.sh"
+        run: melos exec -- "../../tool/verify_pub_score.sh 150"

--- a/packages/test_track/lib/src/domain/override_assignments.dart
+++ b/packages/test_track/lib/src/domain/override_assignments.dart
@@ -37,7 +37,8 @@ class OverrideAssignments {
         options: username != null && password != null
             ? Options(
                 headers: {
-                  'Authorization': 'Basic ${base64Encode(utf8.encode('$username:$password'))}',
+                  'Authorization':
+                      'Basic ${base64Encode(utf8.encode('$username:$password'))}',
                 },
               )
             : null,

--- a/packages/test_track/lib/src/domain/override_assignments.dart
+++ b/packages/test_track/lib/src/domain/override_assignments.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
 import 'package:sturdy_http/sturdy_http.dart';
 import 'package:test_track/src/domain/get_visitor_config.dart';
 import 'package:test_track/test_track.dart';
@@ -22,6 +25,8 @@ class OverrideAssignments {
     required AppVersionBuild appVersionBuild,
     required String visitorId,
     required List<AssignmentOverride> assignmentOverrides,
+    String? username,
+    String? password,
   }) async {
     await _client.execute(
       PostRequest(
@@ -29,6 +34,13 @@ class OverrideAssignments {
         data: NetworkRequestBody.json({
           'assignments': assignmentOverrides.map((a) => a.toJson()).toList(),
         }),
+        options: username != null && password != null
+            ? Options(
+                headers: {
+                  'Authorization': 'Basic ${base64Encode(utf8.encode('$username:$password'))}',
+                },
+              )
+            : null,
       ),
       onResponse: (r) => switch (r) {
         OkNoContent() => null,

--- a/packages/test_track/lib/src/test_track.dart
+++ b/packages/test_track/lib/src/test_track.dart
@@ -209,11 +209,15 @@ class TestTrack {
   /// {@macro override_assignments}
   Future<void> createAssignmentOverrides({
     required List<AssignmentOverride> assignmentOverrides,
+    String? username,
+    String? password,
   }) async {
     final appVisitorConfig = await _overrideAssignments(
       appVersionBuild: _appVersionBuild,
       visitorId: _visitor.id,
       assignmentOverrides: assignmentOverrides,
+      username: username,
+      password: password,
     );
     _updateAppVisitorConfig(appVisitorConfig);
   }

--- a/packages/test_track/test/domain/override_assignments_test.dart
+++ b/packages/test_track/test/domain/override_assignments_test.dart
@@ -36,6 +36,7 @@ void main() {
         )
       ];
       late List<Map<String, dynamic>>? assignmentsFromRequest;
+      late String? authorizationHeaderFromRequest;
 
       setUp(() async {
         charlatan = Charlatan()
@@ -43,8 +44,8 @@ void main() {
             '/api/v2/visitors/$visitorId/assignment_overrides',
             (request) {
               final data = request.body as Map<String, Object?>?;
-              assignmentsFromRequest =
-                  data?['assignments'] as List<Map<String, Object?>>?;
+              assignmentsFromRequest = data?['assignments'] as List<Map<String, Object?>>?;
+              authorizationHeaderFromRequest = request.headers['Authorization'] as String?;
               return CharlatanHttpResponse(statusCode: 204);
             },
           )
@@ -65,8 +66,7 @@ void main() {
         );
       });
 
-      test('it makes a POST request to the correct url with the correct body',
-          () async {
+      test('it makes a POST request to the correct url with the correct body', () async {
         await subject.call(
           appVersionBuild: AppVersionBuildFactory.build(),
           visitorId: visitorId,
@@ -83,8 +83,19 @@ void main() {
         );
       });
 
-      test('it invokes GetVisitorConfig and returns refreshed AppVisitorConfig',
-          () async {
+      test('it includes the username and password in the request if they are provided', () async {
+        await subject.call(
+          appVersionBuild: AppVersionBuildFactory.build(),
+          visitorId: visitorId,
+          assignmentOverrides: assignmentOverrides,
+          username: 'username',
+          password: 'password',
+        );
+
+        expect(authorizationHeaderFromRequest, 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=');
+      });
+
+      test('it invokes GetVisitorConfig and returns refreshed AppVisitorConfig', () async {
         final result = await subject.call(
           appVersionBuild: AppVersionBuildFactory.build(),
           visitorId: visitorId,

--- a/packages/test_track/test/domain/override_assignments_test.dart
+++ b/packages/test_track/test/domain/override_assignments_test.dart
@@ -44,8 +44,10 @@ void main() {
             '/api/v2/visitors/$visitorId/assignment_overrides',
             (request) {
               final data = request.body as Map<String, Object?>?;
-              assignmentsFromRequest = data?['assignments'] as List<Map<String, Object?>>?;
-              authorizationHeaderFromRequest = request.headers['Authorization'] as String?;
+              assignmentsFromRequest =
+                  data?['assignments'] as List<Map<String, Object?>>?;
+              authorizationHeaderFromRequest =
+                  request.headers['Authorization'] as String?;
               return CharlatanHttpResponse(statusCode: 204);
             },
           )
@@ -66,7 +68,8 @@ void main() {
         );
       });
 
-      test('it makes a POST request to the correct url with the correct body', () async {
+      test('it makes a POST request to the correct url with the correct body',
+          () async {
         await subject.call(
           appVersionBuild: AppVersionBuildFactory.build(),
           visitorId: visitorId,
@@ -83,7 +86,9 @@ void main() {
         );
       });
 
-      test('it includes the username and password in the request if they are provided', () async {
+      test(
+          'it includes the username and password in the request if they are provided',
+          () async {
         await subject.call(
           appVersionBuild: AppVersionBuildFactory.build(),
           visitorId: visitorId,
@@ -92,10 +97,12 @@ void main() {
           password: 'password',
         );
 
-        expect(authorizationHeaderFromRequest, 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=');
+        expect(
+            authorizationHeaderFromRequest, 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=');
       });
 
-      test('it invokes GetVisitorConfig and returns refreshed AppVisitorConfig', () async {
+      test('it invokes GetVisitorConfig and returns refreshed AppVisitorConfig',
+          () async {
         final result = await subject.call(
           appVersionBuild: AppVersionBuildFactory.build(),
           visitorId: visitorId,

--- a/packages/test_track_test_support/lib/src/fake_test_track.dart
+++ b/packages/test_track_test_support/lib/src/fake_test_track.dart
@@ -118,7 +118,9 @@ class FakeTestTrack implements TestTrack {
 
   @override
   Future<void> createAssignmentOverrides(
-      {required List<AssignmentOverride> assignmentOverrides, String? username, String? password}) async {
+      {required List<AssignmentOverride> assignmentOverrides,
+      String? username,
+      String? password}) async {
     _visitor = _visitor.copyWith(assignments: [
       ..._visitor.assignments,
       ...assignmentOverrides.map((e) => Assignment(

--- a/packages/test_track_test_support/lib/src/fake_test_track.dart
+++ b/packages/test_track_test_support/lib/src/fake_test_track.dart
@@ -117,9 +117,8 @@ class FakeTestTrack implements TestTrack {
   }
 
   @override
-  Future<void> createAssignmentOverrides({
-    required List<AssignmentOverride> assignmentOverrides,
-  }) async {
+  Future<void> createAssignmentOverrides(
+      {required List<AssignmentOverride> assignmentOverrides, String? username, String? password}) async {
     _visitor = _visitor.copyWith(assignments: [
       ..._visitor.assignments,
       ...assignmentOverrides.map((e) => Assignment(


### PR DESCRIPTION
### 📰 Summary of changes
<!-- Feel free to delete this section if it doesn't apply -->

This PR allows for providing a username and password when invoking `createAssignmentOverrides` which will send those along to the server using a basic authorization header.

### 🧪 Testing done
<!-- Feel free to delete this section if it doesn't apply -->

Tested in a host application and added a unit test
